### PR TITLE
feat(watch): augmentation de la profondeur du scan des md des slides

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,7 +29,7 @@ module.exports = function (grunt) {
                 livereload: 32729
             },
             content: {
-                files: ['Slides/*.md', 'Slides/slides.json']
+                files: ['Slides/**/*.md', 'Slides/slides.json']
             },
             ressources: {
                 files: 'Slides/ressources/**'
@@ -68,7 +68,7 @@ module.exports = function (grunt) {
                             "app.yaml"
                         ]
                     },
-					{
+          {
                         expand: true,
                         dot: true,
                         cwd: "PDF",


### PR DESCRIPTION
Pour la formation `initiation web`, nous avons répartit les slides dans des sous-dossiers.
Les modifications ne provoquent pas de reload car le scan ne traite pas les sous-dossiers.
