### PR TITLE
Add a Dockerfile 'onbuild'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# zenika/formations
+FROM digitallyseamless/nodejs-bower-grunt:0.12
+MAINTAINER Vincent Demeester <vincent.demeester@zenika.com>
+
+# Define the workdir for the rest of the commands
+WORKDIR /data
+
+# Make grunt as entrypoint
+ENTRYPOINT ["grunt"]
+
+# When making child images, run these commands
+# The idea is to build an images for the formation that contains
+# the needed libraries
+ONBUILD COPY package.json /data/
+ONBUILD RUN npm install
+ONBUILD COPY . /data/
+
+WORKDIR /data/


### PR DESCRIPTION
The idea is to push this to a zenika/formations images (using auto-build), so that all other formations can use to define a docker images. (could not re-open #29).

That way, for a new *formation*, it's a really simple ``Dockerfile`` :

```dockerfile
FROM zenika/formations
MAINTAINER John Doe <john.doe@zenika.com>
```

And we could setup an *Automated Build* for it too :wink: .

Signed-off-by: Vincent Demeester <vincent@sbr.pm>