### PR TITLE
Dockerfile Updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,24 @@
 # zenika/formations
-FROM digitallyseamless/nodejs-bower-grunt:0.12
+FROM node:0.10
 MAINTAINER Vincent Demeester <vincent.demeester@zenika.com>
 
-# Define the workdir for the rest of the commands
-WORKDIR /data
+# Install zenika-formation-framework (ZFF)
+ENV ZFF_INSTALL_DIR /data/node_modules/zenika-formation-framework
+RUN mkdir -p $ZFF_INSTALL_DIR
+COPY package.json $ZFF_INSTALL_DIR/
+WORKDIR $ZFF_INSTALL_DIR
+RUN npm install
 
-# Make grunt as entrypoint
-ENTRYPOINT ["grunt"]
+# Copy content from ZFF git repository
+COPY . $ZFF_INSTALL_DIR/
 
-# When making child images, run these commands
-# The idea is to build an images for the formation that contains
-# the needed libraries
-ONBUILD COPY package.json /data/
-ONBUILD RUN npm install
-ONBUILD COPY . /data/
-
+# Install grunt
 WORKDIR /data/
+RUN npm install grunt@^0.4.5 
+RUN npm install -g grunt-cli
+
+# Ports 8000 (slides) and 32729 (live reload) should be exposed
+EXPOSE 8000 32729
+
+# Make grunt the default command
+CMD ["grunt"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # zenika/formations
 FROM node:0.10
-MAINTAINER Vincent Demeester <vincent.demeester@zenika.com>
+MAINTAINER Zenika <http://www.zenika.com>
 
 # Install zenika-formation-framework (ZFF)
 ENV ZFF_INSTALL_DIR /data/node_modules/zenika-formation-framework


### PR DESCRIPTION
L'idée c'est avoir une image Docker unique, avec le framework pré-installé, qui permet de lancer toutes les formations Zenika. 

J'ai donc modifié le Dockerfile de la façon suivante :
* Il se base base sur l'image officielle [node:0.10](https://registry.hub.docker.com/_/node/)
* L'application formation-framework est installée sous `/data/node_modules/zenika-formation-framework`
* `grunt` et `grunt-cli` sont également installés
* La commande par défault est `grunt`

Une fois que cette PR sera mergée on pourra créer un *automated build* de l'image `zenika/formation-framework` sur DockeHub et cette image permettra de lancer toutes les formations Zenika en utilisant la commande :
``` sh
docker run -d -P \
           -v $PWD/Slides:/data/Slides \
           -v $PWD/Gruntfile.js:/data/Gruntfile.js \
           -v $PWD/package.json:/data/package.json 
           zenika/formation-framework
```

Pour tester, l'image mariolet/zenika-formation-framework:0.4.0 est déjà disponible

Une fois la PR mergée je vais mettre à jour le script `dformation` dans [formation--modele](https://github.com/zenika/formation--modele).

