### PR TITLE
Fix the title in summary.html

### DIFF
--- a/summary.html
+++ b/summary.html
@@ -35,7 +35,7 @@
 <body>
   <div class="container">
     <div class="center">
-      <h1>Formation AngularJs</h1>
+      <h1>FORMATION_DESCRIPTION</h1>
     </div>
     <div class="center">
       <ul>


### PR DESCRIPTION
Dans la *page de garde* `summary.html` le titre de la formation étatait hardcodé. 

J'ai remplacé `Formation AngularJs`  avec le placeholder `FORMATION_DESCRIPTION` ;-)