### PR TITLE
Docker image improvements

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,6 +52,28 @@ module.exports = function (grunt) {
       dist: ['dist/**']
     },
     copy: {
+      rename: {
+        files: [
+          {
+            expand: true, 
+            cwd: frameworkPath, 
+            src: 'index.html', 
+            dest: 'slides.html', 
+            rename: function(dest, src) {
+              return frameworkPath + '/' + dest;
+            }
+          },
+          {
+            expand: true, 
+            cwd: frameworkPath, 
+            src: 'summary.html', 
+            dest: 'index.html', 
+            rename: function(dest, src) {
+              return frameworkPath + '/' + dest;
+            }
+          }
+        ]
+      },
       dist: {
         files: [
         {
@@ -198,7 +220,7 @@ module.exports = function (grunt) {
         },
         src: 'dist/reveal/run*.js'
       }
-    }
+    },
   });
 
   grunt.loadTasks(__dirname + '/node_modules/grunt-sed/tasks');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -89,7 +89,7 @@ module.exports = function (grunt) {
           expand: true,
           dot: true,
           cwd: "PDF",
-          dest: "<%= dist %>",
+          dest: "<%= dist %>/pdf",
           src: [
           "*.pdf"
           ]

--- a/summary.html
+++ b/summary.html
@@ -40,8 +40,8 @@
     <div class="center">
       <ul>
         <li><h2><a href="slides.html">Slides en ligne</a></h2></li>
-        <li><h2><a target="_blank" href="FORMATION_SLIDES.pdf">Slides en PDF</a></h2></li>
-        <li><h2><a target="_blank" href="FORMATION_CAHIER.pdf">Cahier d'exercices en PDF</a></h2></li>
+        <li><h2><a target="_blank" href="pdf/FORMATION_SLIDES.pdf">Slides en PDF</a></h2></li>
+        <li><h2><a target="_blank" href="pdf/FORMATION_CAHIER.pdf">Cahier d'exercices en PDF</a></h2></li>
         <li><h2><a target="_blank" href="FORMATION_GITHUB">Github</a></h2></li>
         <li><h2><a target="_blank" href="FORMATION_HOMEPAGE">sur le site Zenika</a></h2></li>
       </ul>


### PR DESCRIPTION
*NOTE: Cette PR est liée à la pull request [#41 de Formation--Modele](https://github.com/Zenika/Formation--Modele/pull/41)*  

**Le Besoin**
Afficher la page de garde, non seulement sur app engine, mais aussi en local, en utilisant l'image Docker `zenika/formation-framework`. 

**Les Problèmes**
* Les fichiers `index.html` et `summary.html` doivent être renommés en `slides.html` et `index.html` respectivement. Et cela doit se faire après avoir lancé `grunt sed`. Mais avant de lancer `grunt displaySlides` :smile:. Et même si le task `copy:dist` fait déjà le job de renaming, ce task fait beaucoup de choses (ça prend du temps) et les fichiers sont copiés dans le repertoire dist (ce qui pose problème pour le live reloading).
* La page de garde `summary.html` a des liens vers les PDF. Ces PDF se trouver dans le folder root de l'application, la où se trouvent aussi d'autres fichiers et repertoires. Or les `.pdf` tout comme les `.md` sont *copiés* dans le conteneur zenika/formation-framework avec le mechanisme des volumes. Et les *copier* dans un répertoire dédié rendrait franchement tout beaucoup plus simple.

**Les solutions**
* Ajouter, `copy:rename`, un task `grunt` de renommage des fichiers `index.html` et `summary.html` dans `Gruntfile.js`
* Changer le répertoire où `summary.html` s'attend les `.pdf`et modifier les tasks `grunt` qui copient les `.pdf`.