### PR TITLE
npm scripts and npm 3 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,8 @@ RUN npm install
 # Copy content from ZFF git repository
 COPY . $ZFF_INSTALL_DIR/
 
-# Install grunt
-WORKDIR /data/
-RUN npm install grunt@^0.4.5 
-RUN npm install -g grunt-cli
-
 # Ports 8000 (slides) and 32729 (live reload) should be exposed
 EXPOSE 8000 32729
 
 # Make grunt the default command
-CMD ["grunt"]
+CMD ["npm", "start"]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function (grunt) {
     dist: "dist",
     connect: {
       options: {
-        base: [__dirname, 'Slides/'],
+        base: [__dirname, 'node_modules/', 'Slides/'],
         hostname: '0.0.0.0',
         port: port
       },
@@ -227,13 +227,13 @@ module.exports = function (grunt) {
     },
   });
 
-  grunt.loadTasks(__dirname + '/node_modules/grunt-sed/tasks');
-  grunt.loadTasks(__dirname + '/node_modules/grunt-contrib-connect/tasks');
-  grunt.loadTasks(__dirname + '/node_modules/grunt-contrib-watch/tasks');
-  grunt.loadTasks(__dirname + '/node_modules/grunt-contrib-clean/tasks');
-  grunt.loadTasks(__dirname + '/node_modules/grunt-contrib-copy/tasks');
-  grunt.loadTasks(__dirname + '/node_modules/grunt-filerev/tasks');
-  grunt.loadTasks(__dirname + '/node_modules/grunt-filerev-replace/tasks');
+  grunt.loadNpmTasks('grunt-sed');
+  grunt.loadNpmTasks('grunt-contrib-connect');
+  grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-filerev');
+  grunt.loadNpmTasks('grunt-filerev-replace');
 
   grunt.registerTask('package', ['sed', 'pdf', 'clean:dist', 'copy:dist', 'filerev-all']);
   grunt.registerTask('filerev-all', ['filerev', 'filerev_replace']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,7 @@
+/* Ce Gruntfile ne contient pas le build pour le framework mais pour les formations basées sur le framework. Les
+ * formations ont leur propres Gruntfile qui vient charger les tâches contenues dans celui-ci via un `loadTasks`.
+ */
+
 module.exports = function (grunt) {
 
   var port = grunt.option('port') || 8000;
@@ -55,19 +59,19 @@ module.exports = function (grunt) {
       rename: {
         files: [
           {
-            expand: true, 
-            cwd: frameworkPath, 
-            src: 'index.html', 
-            dest: 'slides.html', 
+            expand: true,
+            cwd: frameworkPath,
+            src: 'index.html',
+            dest: 'slides.html',
             rename: function(dest, src) {
               return frameworkPath + '/' + dest;
             }
           },
           {
-            expand: true, 
-            cwd: frameworkPath, 
-            src: 'summary.html', 
-            dest: 'index.html', 
+            expand: true,
+            cwd: frameworkPath,
+            src: 'summary.html',
+            dest: 'index.html',
             rename: function(dest, src) {
               return frameworkPath + '/' + dest;
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,8 @@
  * formations ont leur propres Gruntfile qui vient charger les tâches contenues dans celui-ci via un `loadTasks`.
  */
 
+var path = require("path");
+
 module.exports = function (grunt) {
 
   var port = grunt.option('port') || 8000;
@@ -9,13 +11,13 @@ module.exports = function (grunt) {
   var prefixPdfName = 'Zenika-Formation' + (configFormation.name ? '-' + configFormation.name : '');
   var slidesPdfName = prefixPdfName + '-Slides';
   var cahierExercicesPdfName = prefixPdfName + '-CahierExercices';
-  var frameworkPath = 'node_modules/zenika-formation-framework';
+  var frameworkPath = __dirname;
 
   grunt.initConfig({
     dist: "dist",
     connect: {
       options: {
-        base: [__dirname, 'node_modules/', 'Slides/'],
+        base: [frameworkPath, 'node_modules/', 'Slides/'],
         hostname: '0.0.0.0',
         port: port
       },
@@ -43,13 +45,13 @@ module.exports = function (grunt) {
         files: 'Slides/ressources/**'
       },
       reveal: {
-        files: __dirname + '/reveal/**'
+        files: path.join(frameworkPath, 'reveal/**')
       },
       index: {
-        files: __dirname + '/index.html'
+        files: path.join(frameworkPath, 'index.html')
       },
       gruntfile: {
-        files: __dirname + '/Gruntfile.js'
+        files: path.join(frameworkPath, 'Gruntfile.js')
       }
     },
     clean: {
@@ -64,7 +66,7 @@ module.exports = function (grunt) {
             src: 'index.html',
             dest: 'slides.html',
             rename: function(dest, src) {
-              return frameworkPath + '/' + dest;
+              return path.join(frameworkPath, dest);
             }
           },
           {
@@ -73,7 +75,7 @@ module.exports = function (grunt) {
             src: 'summary.html',
             dest: 'index.html',
             rename: function(dest, src) {
-              return frameworkPath + '/' + dest;
+              return path.join(frameworkPath, dest);
             }
           }
         ]
@@ -157,49 +159,49 @@ module.exports = function (grunt) {
     },
     sed: {
       dist: {
-        path: [frameworkPath + '/index.html'],
+        path: [path.join(frameworkPath, 'index.html')],
         pattern: 'FORMATION_NAME',
         replacement: slidesPdfName,
         recursive: true
       },
       description: {
-        path: [frameworkPath + '/summary.html'],
+        path: [path.join(frameworkPath, 'summary.html')],
         pattern: 'FORMATION_DESCRIPTION',
         replacement: configFormation.description,
         recursive: true
       },
       slidesPdf: {
-        path: [frameworkPath + '/summary.html'],
+        path: [path.join(frameworkPath, 'summary.html')],
         pattern: 'FORMATION_SLIDES',
         replacement: slidesPdfName,
         recursive: true
       },
       cahierExercicesPdf: {
-        path: [frameworkPath + '/summary.html'],
+        path: [path.join(frameworkPath, 'summary.html')],
         pattern: 'FORMATION_CAHIER',
         replacement: cahierExercicesPdfName,
         recursive: true
       },
       github: {
-        path: [frameworkPath + '/summary.html'],
+        path: [path.join(frameworkPath, 'summary.html')],
         pattern: 'FORMATION_GITHUB',
         replacement: configFormation.repository.url,
         recursive: true
       },
       homepage: {
-        path: [frameworkPath + '/summary.html'],
+        path: [path.join(frameworkPath, 'summary.html')],
         pattern: 'FORMATION_HOMEPAGE',
         replacement: configFormation.homepage,
         recursive: true
       },
       yamlName: {
-        path: [frameworkPath + '/app.yaml'],
+        path: [path.join(frameworkPath, 'app.yaml')],
         pattern: 'FORMATION_DEPLOY_NAME',
         replacement: configFormation.config.deploy.name,
         recursive: true
       },
       yamlVersion: {
-        path: [frameworkPath + '/app.yaml'],
+        path: [path.join(frameworkPath, 'app.yaml')],
         pattern: 'FORMATION_DEPLOY_VERSION',
         replacement: configFormation.config.deploy.version.replace(/\./g, '-'),
         recursive: true
@@ -244,19 +246,19 @@ module.exports = function (grunt) {
     var done = this.async();
 
     var markdownpdf = require("markdown-pdf"),
-    path = require('path'),
     split = require("split"),
     through = require("through"),
     duplexer = require("duplexer");
 
+    var parts;
     try {
-      var parts = require(path.resolve(__dirname, "..", "..", "CahierExercices", "parts.json"));
+      parts = require("./CahierExercices/parts.json");
     }
     catch (e) {
       parts = ["Cahier.md"];
     }
-    var cssPath = path.resolve(__dirname, "styleCahierExercice.css");
-    var highlightPath = path.resolve(__dirname, "reveal", "theme-zenika", "code.css");
+    var cssPath = path.resolve(frameworkPath, "styleCahierExercice.css");
+    var highlightPath = path.resolve(frameworkPath, "reveal/theme-zenika/code.css");
     var pdfPath = 'PDF/' + cahierExercicesPdfName + '.pdf';
     var files = parts.map(function (f) {
       return "CahierExercices/" + f;
@@ -295,7 +297,7 @@ module.exports = function (grunt) {
       highlightCssPath: highlightPath,
       preProcessMd: preprocessMd,
       remarkable: {html: true},
-      cwd: __dirname
+      cwd: frameworkPath
     })
     .concat.from(files)
     .to(pdfPath,
@@ -310,12 +312,11 @@ module.exports = function (grunt) {
     var
     childProcess = require('child_process'),
     phantomjs = require('phantomjs'),
-    path = require('path'),
     binPath = phantomjs.path,
     done = grunt.task.current.async()
     ;
 
-    var fullPath = path.join(__dirname, 'reveal/plugins/print-pdf/print-pdf.js');
+    var fullPath = path.join(frameworkPath, 'reveal/plugins/print-pdf/print-pdf.js');
 
     var childArgs = [
     fullPath,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@
  * formations ont leur propres Gruntfile qui vient charger les tâches contenues dans celui-ci via un `loadTasks`.
  */
 
-var path = require("path");
+var path = require('path');
 
 module.exports = function (grunt) {
 
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
   var frameworkPath = __dirname;
 
   grunt.initConfig({
-    dist: "dist",
+    dist: 'dist',
     connect: {
       options: {
         base: [frameworkPath, 'node_modules/', 'Slides/'],
@@ -85,73 +85,73 @@ module.exports = function (grunt) {
         {
           expand: true,
           dot: true,
-          cwd: "Slides",
-          dest: "<%= dist %>",
+          cwd: 'Slides',
+          dest: '<%= dist %>',
           src: [
-          "./**"
+          './**'
           ]
         },
         {
           expand: true,
           dot: true,
-          cwd: "PDF",
-          dest: "<%= dist %>/pdf",
+          cwd: 'PDF',
+          dest: '<%= dist %>/pdf',
           src: [
-          "*.pdf"
+          '*.pdf'
           ]
         },
         {
           expand: true,
           cwd: frameworkPath,
-          dest: "<%= dist %>",
+          dest: '<%= dist %>',
           src: [
-          "styleCahierExercice.css",
-          "reveal/**",
-          "node_modules/reveal.js/css/reveal.min.css",
-          "node_modules/reveal.js/lib/js/head.min.js",
-          "node_modules/reveal.js/js/reveal.min.js",
-          "node_modules/reveal.js/css/print/pdf.css",
-          "node_modules/reveal.js/plugin/**"
+          'styleCahierExercice.css',
+          'reveal/**',
+          'node_modules/reveal.js/css/reveal.min.css',
+          'node_modules/reveal.js/lib/js/head.min.js',
+          'node_modules/reveal.js/js/reveal.min.js',
+          'node_modules/reveal.js/css/print/pdf.css',
+          'node_modules/reveal.js/plugin/**'
           ]
         },
         {
           expand: true,
           cwd: frameworkPath,
           flatten: true,
-          dest: "<%= dist %>",
+          dest: '<%= dist %>',
           src: [
-          "reveal/theme-zenika/favicon.png"
+          'reveal/theme-zenika/favicon.png'
           ]
         },
         {
           expand: true,
           cwd: frameworkPath,
-          dest: "<%= dist %>",
+          dest: '<%= dist %>',
           src: [
-          "index.html"
+          'index.html'
           ],
           rename: function(dest, src) {
-            return dest + "/slides.html";
+            return dest + '/slides.html';
           }
         },
         {
           expand: true,
           cwd: frameworkPath,
-          dest: "<%= dist %>",
+          dest: '<%= dist %>',
           src: [
-          "summary.html"
+          'summary.html'
           ],
           rename: function(dest, src) {
-            return dest + "/index.html";
+            return dest + '/index.html';
           }
         },
         {
           expand: true,
           dot: true,
           cwd: frameworkPath,
-          dest: "<%= dist %>",
+          dest: '<%= dist %>',
           src: [
-          "app.yaml"
+          'app.yaml'
           ]
         }
         ]
@@ -245,28 +245,28 @@ module.exports = function (grunt) {
   grunt.registerTask('generateCahierExercice', function () {
     var done = this.async();
 
-    var markdownpdf = require("markdown-pdf"),
-    split = require("split"),
-    through = require("through"),
-    duplexer = require("duplexer");
+    var markdownpdf = require('markdown-pdf'),
+    split = require('split'),
+    through = require('through'),
+    duplexer = require('duplexer');
 
     var parts;
     try {
-      parts = require("./CahierExercices/parts.json");
+      parts = require('./CahierExercices/parts.json');
     }
     catch (e) {
-      parts = ["Cahier.md"];
+      parts = ['Cahier.md'];
     }
-    var cssPath = path.resolve(frameworkPath, "styleCahierExercice.css");
-    var highlightPath = path.resolve(frameworkPath, "reveal/theme-zenika/code.css");
+    var cssPath = path.resolve(frameworkPath, 'styleCahierExercice.css');
+    var highlightPath = path.resolve(frameworkPath, 'reveal/theme-zenika/code.css');
     var pdfPath = 'PDF/' + cahierExercicesPdfName + '.pdf';
     var files = parts.map(function (f) {
-      return "CahierExercices/" + f;
+      return 'CahierExercices/' + f;
     });
 
-    console.log("Using CSS file", cssPath);
-    console.log("Using highlightPath file", highlightPath);
-    console.log("Using md sources files", files);
+    console.log('Using CSS file', cssPath);
+    console.log('Using highlightPath file', highlightPath);
+    console.log('Using md sources files', files);
 
 
     function preprocessMd() {
@@ -277,7 +277,7 @@ module.exports = function (grunt) {
         .replace(/!\[([^\]]*)][\s]*\(([^\)]*)\)/g, function (match, p1, p2, src) {
           return '![' + p1 + '](' + path.resolve('CahierExercices', p2) + ')';
         })
-        .replace(/<img (.*)src=["|']([^\"\']*)["|'](.*)>/g, function (match, p1, p2, p3, src) {
+        .replace(/<img (.*)src=['|']([^\'\']*)['|'](.*)>/g, function (match, p1, p2, p3, src) {
           return '<img ' + p1 + 'src="' + path.resolve('CahierExercices', p2) + '"' + p3 + '>';
         })
         .replace(/\{Titre-Formation}/g, function () {
@@ -302,7 +302,7 @@ module.exports = function (grunt) {
     .concat.from(files)
     .to(pdfPath,
       function (v) {
-        console.log("PDF généré: " + pdfPath);
+        console.log('PDF généré: ' + pdfPath);
         done();
       }
       );

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -310,18 +310,18 @@ module.exports = function (grunt) {
 
   grunt.registerTask('doGenerateSlidesPDF', function () {
     var
-    childProcess = require('child_process'),
-    phantomjs = require('phantomjs'),
-    binPath = phantomjs.path,
-    done = grunt.task.current.async()
+      childProcess = require('child_process'),
+      phantomjs = require('phantomjs'),
+      binPath = phantomjs.path,
+      done = grunt.task.current.async()
     ;
 
     var fullPath = path.join(frameworkPath, 'reveal/plugins/print-pdf/print-pdf.js');
 
     var childArgs = [
-    fullPath,
-    'http://localhost:' + port + '?print-pdf',
-    'PDF/' + slidesPdfName + '.pdf'
+      fullPath,
+      'http://localhost:' + port + '?print-pdf',
+      'PDF/' + slidesPdfName + '.pdf'
     ];
 
     childProcess.execFile(binPath, childArgs, function (error, stdout, stderr) {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Zenika Formation Framework
+# Zenika Formation Framework
 
 Utilisé par toutes nos formations, comme sur le [Modèle](https://github.com/Zenika/Formation--Modele)
 
@@ -17,7 +17,6 @@ Le framework des formations est un package npm à part entière. Il est importé
 Comme il s'agit d'un package privé (il n'est pas publié sur http://npmjs.org), sa déclaration dans le fichier package.json de chaque formation se fait de la manière suivante :
 ```javascript
   "dependencies": {
-    "grunt": "^0.4.5",
     "zenika-formation-framework": "git+ssh://git@github.com:Zenika/Formation--Framework.git#tags/X.Y.Z"
   }
 ```

--- a/index.html
+++ b/index.html
@@ -8,13 +8,13 @@
 
     <title>FORMATION_NAME</title>
     <link rel="icon" type="image/png" href="favicon.png">
-    <link rel="stylesheet" href="node_modules/reveal.js/css/reveal.min.css">
+    <link rel="stylesheet" href="reveal.js/css/reveal.min.css">
     <link rel="stylesheet" href="reveal/theme-zenika/theme.css" id="theme">
     <link rel="stylesheet" href="reveal/theme-zenika/code.css" id="syntaxHighlighting">
     <link rel="stylesheet" href="ressources/custom.css" id="custom">
 
     <!--[if lt IE 9]>
-    <script src="node_modules/reveal.js/lib/js/html5shiv.js"></script>
+    <script src="reveal.js/lib/js/html5shiv.js"></script>
     <![endif]-->
   </head>
 
@@ -28,8 +28,8 @@
       </footer>
     </div>
 
-    <script src="node_modules/reveal.js/lib/js/head.min.js"></script>
-    <script src="node_modules/reveal.js/js/reveal.min.js"></script>
+    <script src="reveal.js/lib/js/head.min.js"></script>
+    <script src="reveal.js/js/reveal.min.js"></script>
     <script src="reveal/run.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   },
   "private": "true",
   "dependencies": {
+    "duplexer": "^0.1.1",
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-connect": "~0.9.0",
     "grunt-contrib-copy": "^0.8.0",
@@ -17,13 +20,9 @@
     "grunt-filerev-replace": "^0.1.4",
     "grunt-sed": "~0.1.0",
     "markdown-pdf": "^5.1.0",
-    "through": "^2.3.6",
-    "duplexer": "^0.1.1",
-    "split": "^0.3.3",
     "phantomjs": "^1.9.13",
-    "reveal.js": "^2.6.2"
-  },
-  "devDependencies": {
-    "grunt": "^0.4.5"
+    "reveal.js": "^2.6.2",
+    "split": "^0.3.3",
+    "through": "^2.3.6"
   }
 }

--- a/reveal/run.js
+++ b/reveal/run.js
@@ -14,7 +14,7 @@
       linkElement.href = stylesheet;
       document.getElementsByTagName('head')[0].appendChild(linkElement);
     }
-    addStylesheetWhenUrlMatches(/print-pdf/gi, '/node_modules/reveal.js/css/print/pdf.css');
+    addStylesheetWhenUrlMatches(/print-pdf/gi, '/reveal.js/css/print/pdf.css');
     addStylesheetWhenUrlMatches(/print-pdf/gi, '/reveal/theme-zenika/pdf.css');
     addStylesheetWhenUrlMatches(/edition/gi, '/reveal/theme-zenika/edition.css');
   }
@@ -56,10 +56,10 @@
 
       // Optional libraries used to extend on reveal.js
       dependencies: [
-        { src: 'node_modules/reveal.js/lib/js/classList.js', condition: function() { return !document.body.classList; } },
-        { src: 'node_modules/reveal.js/plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
-        { src: 'node_modules/reveal.js/plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
-        { src: 'node_modules/reveal.js/plugin/highlight/highlight.js', async: true, callback: function() {
+        { src: 'reveal.js/lib/js/classList.js', condition: function() { return !document.body.classList; } },
+        { src: 'reveal.js/plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
+        { src: 'reveal.js/plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
+        { src: 'reveal.js/plugin/highlight/highlight.js', async: true, callback: function() {
             // Define Plain Text language for Console output
             hljs.LANGUAGES.text = {
               keywords: '',
@@ -70,8 +70,8 @@
             hljs.initHighlightingOnLoad();
           }
         },
-        { src: 'node_modules/reveal.js/plugin/zoom-js/zoom.js', async: true, condition: function() { return !!document.body.classList; } },
-        { src: 'node_modules/reveal.js/plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } },
+        { src: 'reveal.js/plugin/zoom-js/zoom.js', async: true, condition: function() { return !!document.body.classList; } },
+        { src: 'reveal.js/plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } },
         { src: 'reveal/plugins/zenika-footer/zenika-footer.js', condition: function() { return !!document.body.classList; } }
       ]
     });


### PR DESCRIPTION
Deux éléments dans cette PR :
- Pour que les formations puissent utiliser les npm scripts plutôt que d'avoir à installer Grunt, le framework ramènent maintenant `grunt` et `grunt-cli` comme dépendances.
  - Les formations n'ont plus à dépendre de `grunt` et peuvent utiliser la commande `grunt` dans leurs npm scripts.
  - Suite à cette PR, il faudrait tagguer une nouvelle version afin que les formations puissent avoir accès à cette feature. Je ferais un PR pour upgrader le modèle dès que ce sera fait.
- Pour que le framework soit compatible avec npm 3, il ne suppose plus que les dépendances sont installées en arborescence (npm 3 installe tout à plat).
  - J'en ai profité pour nettoyer un peu le code qui tourne autour des paths dans le Gruntfile
  - J'en ai profité pour éliminer le mélange single/double quotes dans le Gruntfile
