### PR TITLE
chore: montée de version de Node dans le Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # zenika/formations
-FROM node:0.10
+FROM node:4.2
 MAINTAINER Zenika <http://www.zenika.com>
 
 # Install zenika-formation-framework (ZFF)
@@ -14,7 +14,7 @@ COPY . $ZFF_INSTALL_DIR/
 
 # Install grunt
 WORKDIR /data/
-RUN npm install grunt@^0.4.5 
+RUN npm install grunt@^0.4.5
 RUN npm install -g grunt-cli
 
 # Ports 8000 (slides) and 32729 (live reload) should be exposed


### PR DESCRIPTION
- cette version version reste avec npm 2 donc pas de problème de build
- cette version enlève l'erreur :
  - `warning: possible EventEmitter memory leak detected`
- c'est une version LTS donc plutôt positive pour la CI