### PR TITLE
PDF, Chrome et debug

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,5 +20,5 @@ insert_final_newline = true
 trim_trailing_whitespace = false
 indent_size = 2
 
-[{*.json,*.js}]
+[{*.json,*.js,*.css}]
 indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+0.4.5:
+- date: 2015-10-26
+- changes:
+  - feat: ouverture forcée dans Chrome
+  - fix: correction de la génération des PDF avec PhantomJS 1.x
+  - fix: ajout d'un polyfill qui ne s'active que si les `Promise` n'existe pas dans le browser
+  - feat: ajout d'un mode debug pour les PDF
+  - feat: screenshot & HTML sauvegardé en mode debug
+  - fix: augmentation du temps d'attente avant la création du PDF  avec PhantomJS 1.x (1000ms -> 10000ms)
+0.4.4:
+- date: 2015-10-18
+- changes:
+  - correction pour GAE
 0.4.3:
 - date: 2015-10-08
 - changes:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,8 +70,7 @@ module.exports = function (grunt) {
             rename: function (dest) {
               return frameworkPath + '/' + dest;
             }
-          },
-          {
+          }, {
             expand: true,
             cwd: frameworkPath,
             src: 'summary.html',
@@ -92,8 +91,7 @@ module.exports = function (grunt) {
             src: [
               './**'
             ]
-          },
-          {
+          }, {
             expand: true,
             dot: true,
             cwd: 'PDF',
@@ -101,8 +99,7 @@ module.exports = function (grunt) {
             src: [
               '*.pdf'
             ]
-          },
-          {
+          }, {
             expand: true,
             cwd: frameworkPath,
             dest: '<%= dist %>',
@@ -115,8 +112,7 @@ module.exports = function (grunt) {
               'node_modules/reveal.js/css/print/pdf.css',
               'node_modules/reveal.js/plugin/**'
             ]
-          },
-          {
+          }, {
             expand: true,
             cwd: frameworkPath,
             flatten: true,
@@ -124,8 +120,7 @@ module.exports = function (grunt) {
             src: [
               'reveal/theme-zenika/favicon.png'
             ]
-          },
-          {
+          }, {
             expand: true,
             cwd: frameworkPath,
             dest: '<%= dist %>',
@@ -135,8 +130,7 @@ module.exports = function (grunt) {
             rename: function (dest) {
               return dest + '/slides.html';
             }
-          },
-          {
+          }, {
             expand: true,
             cwd: frameworkPath,
             dest: '<%= dist %>',
@@ -146,8 +140,7 @@ module.exports = function (grunt) {
             rename: function (dest) {
               return dest + '/index.html';
             }
-          },
-          {
+          }, {
             expand: true,
             dot: true,
             cwd: frameworkPath,
@@ -305,18 +298,16 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('doGenerateSlidesPDF', function () {
-    var
-      childProcess = require('child_process'),
-      phantomjs = require('phantomjs'),
-      path = require('path'),
-      binPath = phantomjs.path,
-      done = grunt.task.current.async()
-      ;
+    var childProcess = require('child_process');
+    var phantomjs = require('phantomjs');
+    var path = require('path');
+    var binPath = phantomjs.path;
+    var done = grunt.task.current.async();
 
-    var fullPath = path.join(__dirname, 'reveal/plugins/print-pdf/print-pdf.js');
+    var revealFullPath = path.join(__dirname, 'reveal/plugins/print-pdf/print-pdf.js');
 
     var childArgs = [
-      fullPath,
+      revealFullPath,
       'http://localhost:' + port + '?print-pdf',
       'PDF/' + slidesPdfName + '.pdf'
     ];

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,8 +19,8 @@ module.exports = function (grunt) {
         options: {
           livereload: 32729,
           open: {
-            target: 'http://localhost:' + port,
-            appName: 'chrome'
+            target: 'http://localhost:' + port
+            // appName: 'chrome' // commenté temps de faire la bonne mécanique cross-OS
           }
         }
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -309,10 +309,13 @@ module.exports = function (grunt) {
 
     var revealFullPath = path.join(__dirname, 'reveal/plugins/print-pdf/print-pdf.js');
 
+    var debugMode = false;
+
     var childArgs = [
       revealFullPath,
       'http://localhost:' + port + '?print-pdf',
-      'PDF/' + slidesPdfName + '.pdf'
+      'PDF/' + slidesPdfName + '.pdf',
+      debugMode
     ];
 
     childProcess.execFile(binPath, childArgs, function (error, stdout, stderr) {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,10 @@ module.exports = function (grunt) {
       server: {
         options: {
           livereload: 32729,
-          open: 'http://localhost:' + port
+          open: {
+            target: 'http://localhost:' + port,
+            appName: 'chrome'
+          }
         }
       },
       print: {},

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,8 +69,9 @@ gulp.task('serve', ['build'], function () {
   browserSync.init({
     port: fwkConfig.port,
     server: {
-      baseDir: [fwkConfig.outputPath, './Slides']
-    }
+      baseDir: [fwkConfig.outputPath, './Slides'],
+    },
+    browser: ['chrome']
   });
 
   gulp.watch([

--- a/index.html
+++ b/index.html
@@ -41,6 +41,11 @@
     <script src="reveal.js/lib/js/head.min.js"></script>
     <script src="reveal.js/js/reveal.min.js"></script>
 
+    <!-- Polyfill pour PhantomJS 1.x -->
+    <script src="reveal/setimmediate.js"></script>
+    <script src="reveal/promise.js"></script>
+
+    <!-- Reveal runner -->
     <script src="reveal/run.js"></script>
 </body>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zenika-formation-framework",
-  "version": "0.4.3",
+  "version": "0.4.5",
   "description": "Framework for displaying slides and building pdf's for Zenika Training",
   "author": "Zenika",
   "repository": {

--- a/reveal/promise.js
+++ b/reveal/promise.js
@@ -1,0 +1,310 @@
+/**
+ * Promise polyfill v1.0.10
+ * requires setImmediate
+ *
+ * © 2014–2015 Dmitry Korobkin
+ * Released under the MIT license
+ * github.com/Octane/Promise
+ */
+(function (global) {'use strict';
+
+    var STATUS = '[[PromiseStatus]]';
+    var VALUE = '[[PromiseValue]]';
+    var ON_FUlFILLED = '[[OnFulfilled]]';
+    var ON_REJECTED = '[[OnRejected]]';
+    var ORIGINAL_ERROR = '[[OriginalError]]';
+    var PENDING = 'pending';
+    var INTERNAL_PENDING = 'internal pending';
+    var FULFILLED = 'fulfilled';
+    var REJECTED = 'rejected';
+    var NOT_ARRAY = 'not an array.';
+    var REQUIRES_NEW = 'constructor Promise requires "new".';
+    var CHAINING_CYCLE = 'then() cannot return same Promise that it resolves.';
+
+    var setImmediate = global.setImmediate || require('timers').setImmediate;
+    var isArray = Array.isArray || function (anything) {
+        return Object.prototype.toString.call(anything) == '[object Array]';
+    };
+
+    function InternalError(originalError) {
+        this[ORIGINAL_ERROR] = originalError;
+    }
+
+    function isInternalError(anything) {
+        return anything instanceof InternalError;
+    }
+
+    function isObject(anything) {
+        //Object.create(null) instanceof Object → false
+        return Object(anything) === anything;
+    }
+
+    function isCallable(anything) {
+        return typeof anything == 'function';
+    }
+
+    function isPromise(anything) {
+        return anything instanceof Promise;
+    }
+
+    function identity(value) {
+        return value;
+    }
+
+    function thrower(reason) {
+        throw reason;
+    }
+
+    function enqueue(promise, onFulfilled, onRejected) {
+        if (!promise[ON_FUlFILLED]) {
+            promise[ON_FUlFILLED] = [];
+            promise[ON_REJECTED] = [];
+        }
+        promise[ON_FUlFILLED].push(onFulfilled);
+        promise[ON_REJECTED].push(onRejected);
+    }
+
+    function clearAllQueues(promise) {
+        delete promise[ON_FUlFILLED];
+        delete promise[ON_REJECTED];
+    }
+
+    function callEach(queue) {
+        var i;
+        var length = queue.length;
+        for (i = 0; i < length; i++) {
+            queue[i]();
+        }
+    }
+
+    function call(resolve, reject, value) {
+        var anything = toPromise(value);
+        if (isPromise(anything)) {
+            anything.then(resolve, reject);
+        } else if (isInternalError(anything)) {
+            reject(anything[ORIGINAL_ERROR]);
+        } else {
+            resolve(value);
+        }
+    }
+
+    function toPromise(anything) {
+        var then;
+        if (isPromise(anything)) {
+            return anything;
+        }
+        if(isObject(anything)) {
+            try {
+                then = anything.then;
+            } catch (error) {
+                return new InternalError(error);
+            }
+            if (isCallable(then)) {
+                return new Promise(function (resolve, reject) {
+                    setImmediate(function () {
+                        try {
+                            then.call(anything, resolve, reject);
+                        } catch (error) {
+                            reject(error);
+                        }
+                    });
+                });
+            }
+        }
+        return null;
+    }
+
+    function resolvePromise(promise, resolver) {
+        function resolve(value) {
+            if (promise[STATUS] == PENDING) {
+                fulfillPromise(promise, value);
+            }
+        }
+        function reject(reason) {
+            if (promise[STATUS] == PENDING) {
+                rejectPromise(promise, reason);
+            }
+        }
+        try {
+            resolver(resolve, reject);
+        } catch(error) {
+            reject(error);
+        }
+    }
+
+    function fulfillPromise(promise, value) {
+        var queue;
+        var anything = toPromise(value);
+        if (isPromise(anything)) {
+            promise[STATUS] = INTERNAL_PENDING;
+            anything.then(
+                function (value) {
+                    fulfillPromise(promise, value);
+                },
+                function (reason) {
+                    rejectPromise(promise, reason);
+                }
+            );
+        } else if (isInternalError(anything)) {
+            rejectPromise(promise, anything[ORIGINAL_ERROR]);
+        } else {
+            promise[STATUS] = FULFILLED;
+            promise[VALUE] = value;
+            queue = promise[ON_FUlFILLED];
+            if (queue && queue.length) {
+                clearAllQueues(promise);
+                callEach(queue);
+            }
+        }
+    }
+
+    function rejectPromise(promise, reason) {
+        var queue = promise[ON_REJECTED];
+        promise[STATUS] = REJECTED;
+        promise[VALUE] = reason;
+        if (queue && queue.length) {
+            clearAllQueues(promise);
+            callEach(queue);
+        }
+    }
+
+    function Promise(resolver) {
+        var promise = this;
+        if (!isPromise(promise)) {
+            throw new TypeError(REQUIRES_NEW);
+        }
+        promise[STATUS] = PENDING;
+        promise[VALUE] = undefined;
+        resolvePromise(promise, resolver);
+    }
+
+    Promise.prototype.then = function (onFulfilled, onRejected) {
+        var promise = this;
+        var nextPromise;
+        onFulfilled = isCallable(onFulfilled) ? onFulfilled : identity;
+        onRejected = isCallable(onRejected) ? onRejected : thrower;
+        nextPromise = new Promise(function (resolve, reject) {
+            function tryCall(func) {
+                var value;
+                try {
+                    value = func(promise[VALUE]);
+                } catch (error) {
+                    reject(error);
+                    return;
+                }
+                if (value === nextPromise) {
+                    reject(new TypeError(CHAINING_CYCLE));
+                } else {
+                    call(resolve, reject, value);
+                }
+            }
+            function asyncOnFulfilled() {
+                setImmediate(tryCall, onFulfilled);
+            }
+            function asyncOnRejected() {
+                setImmediate(tryCall, onRejected);
+            }
+            switch (promise[STATUS]) {
+                case FULFILLED:
+                    asyncOnFulfilled();
+                    break;
+                case REJECTED:
+                    asyncOnRejected();
+                    break;
+                default:
+                    enqueue(promise, asyncOnFulfilled, asyncOnRejected);
+            }
+        });
+        return nextPromise;
+    };
+
+    Promise.prototype['catch'] = function (onRejected) {
+        return this.then(identity, onRejected);
+    };
+
+    Promise.resolve = function (value) {
+        var anything = toPromise(value);
+        if (isPromise(anything)) {
+            return anything;
+        }
+        return new Promise(function (resolve, reject) {
+            if (isInternalError(anything)) {
+                reject(anything[ORIGINAL_ERROR]);
+            } else {
+                resolve(value);
+            }
+        });
+    };
+
+    Promise.reject = function (reason) {
+        return new Promise(function (resolve, reject) {
+            reject(reason);
+        });
+    };
+
+    Promise.race = function (values) {
+        return new Promise(function (resolve, reject) {
+            var i;
+            var length;
+            if (isArray(values)) {
+                length = values.length;
+                for (i = 0; i < length; i++) {
+                    call(resolve, reject, values[i]);
+                }
+            } else {
+                reject(new TypeError(NOT_ARRAY));
+            }
+        });
+    };
+
+    Promise.all = function (values) {
+        return new Promise(function (resolve, reject) {
+            var fulfilledCount = 0;
+            var promiseCount = 0;
+            var anything;
+            var length;
+            var value;
+            var i;
+            if (isArray(values)) {
+                values = values.slice(0);
+                length = values.length;
+                for (i = 0; i < length; i++) {
+                    value = values[i];
+                    anything = toPromise(value);
+                    if (isPromise(anything)) {
+                        promiseCount++;
+                        anything.then(
+                            function (index) {
+                                return function (value) {
+                                    values[index] = value;
+                                    fulfilledCount++;
+                                    if (fulfilledCount == promiseCount) {
+                                        resolve(values);
+                                    }
+                                };
+                            }(i),
+                            reject
+                        );
+                    } else if (isInternalError(anything)) {
+                        reject(anything[ORIGINAL_ERROR]);
+                    } else {
+                        //[1, , 3] → [1, undefined, 3]
+                        values[i] = value;
+                    }
+                }
+                if (!promiseCount) {
+                    resolve(values);
+                }
+            } else {
+                reject(new TypeError(NOT_ARRAY));
+            }
+        });
+    };
+
+    if (typeof module != 'undefined' && module.exports) {
+        module.exports = global.Promise || Promise;
+    } else if (!global.Promise) {
+        global.Promise = Promise;
+    }
+
+}(this));

--- a/reveal/setimmediate.js
+++ b/reveal/setimmediate.js
@@ -1,0 +1,61 @@
+/**
+ * setImmediate polyfill v1.0.1, supports IE9+
+ * © 2014–2015 Dmitry Korobkin
+ * Released under the MIT license
+ * github.com/Octane/setImmediate
+ */
+window.setImmediate || function () {'use strict';
+
+    var uid = 0;
+    var storage = {};
+    var firstCall = true;
+    var slice = Array.prototype.slice;
+    var message = 'setImmediatePolyfillMessage';
+
+    function fastApply(args) {
+        var func = args[0];
+        switch (args.length) {
+            case 1:
+                return func();
+            case 2:
+                return func(args[1]);
+            case 3:
+                return func(args[1], args[2]);
+        }
+        return func.apply(window, slice.call(args, 1));
+    }
+
+    function callback(event) {
+        var key = event.data;
+        var data;
+        if (typeof key == 'string' && key.indexOf(message) == 0) {
+            data = storage[key];
+            if (data) {
+                delete storage[key];
+                fastApply(data);
+            }
+        }
+    }
+
+    window.setImmediate = function setImmediate() {
+        var id = uid++;
+        var key = message + id;
+        var i = arguments.length;
+        var args = new Array(i);
+        while (i--) {
+            args[i] = arguments[i];
+        }
+        storage[key] = args;
+        if (firstCall) {
+            firstCall = false;
+            window.addEventListener('message', callback);
+        }
+        window.postMessage(key, '*');
+        return id;
+    };
+
+    window.clearImmediate = function clearImmediate(id) {
+        delete storage[message + id];
+    };
+
+}();

--- a/reveal/theme-zenika/pdf.css
+++ b/reveal/theme-zenika/pdf.css
@@ -13,8 +13,8 @@ body {
 }
 
 .reveal .slides section section {
-  height: 210mm !important;
-  min-height: 210mm !important;
+  height: 209mm !important;
+  min-height: 209mm !important;
   padding: 0 40px !important;
 }
 
@@ -27,7 +27,8 @@ body {
 }
 
 .reveal .slides pre > code {
-  font-family: "Inconsolata" !important;
+  overflow: hidden !important;
+  font-family: 'Inconsolata', monospace !important;
 }
 
 .reveal .master-toc-return {
@@ -35,9 +36,9 @@ body {
 }
 
 .reveal em {
-	font-weight: bold;
+    font-weight: bold;
 }
 
 .reveal strong {
-	font-weight: bold;
+    font-weight: bold;
 }

--- a/reveal/theme-zenika/theme.css
+++ b/reveal/theme-zenika/theme.css
@@ -1,21 +1,21 @@
 @font-face {
   font-family: 'Roboto';
-  src: url("fonts/Roboto-Regular.ttf") format("truetype");
+  src: url('fonts/Roboto-Regular.ttf') format('truetype');
 }
 
 @font-face {
   font-family: 'Roboto Light';
-  src: url("fonts/Roboto-Light.ttf") format("truetype");
+  src: url('fonts/Roboto-Light.ttf') format('truetype');
 }
 
 @font-face {
   font-family: "Architect's Daughter";
-  src: url("fonts/ArchitectsDaughter.ttf") format("truetype");
+  src: url('fonts/ArchitectsDaughter.ttf') format('truetype');
 }
 
 @font-face {
   font-family: 'Inconsolata';
-  src: url("fonts/Inconsolata-Regular.ttf") format("truetype");
+  src: url('fonts/Inconsolata-Regular.ttf') format('truetype');
 }
 
 /*********************************************
@@ -26,7 +26,7 @@ body {
 }
 
 .reveal {
-  font-family: "Arial", sans-serif;
+  font-family: 'Arial', sans-serif;
   font-size: 28px;
   font-weight: normal;
   color: #333333;
@@ -54,7 +54,7 @@ body {
 }
 
 .reveal .slides h2:after {
-  content: url("images/zenika-logo-small.png");
+  content: url('images/zenika-logo-small.png');
   float: right;
   margin-top: -14px;
   margin-right: 20px;
@@ -92,7 +92,7 @@ body {
 .reveal .slides table tr th {
   border: 1px solid #AAAAAA;
   border-bottom: 5px solid #b30c37;
-  //background-color: #AAAAAA;
+/*  background-color: #AAAAAA;*/
   color : #000000;
 }
 
@@ -111,7 +111,7 @@ body {
   float: right;
   color: #b30c37;
   text-align: right;
-  font-family: "Roboto Light", sans-serif;
+  font-family: 'Roboto Light', sans-serif;
   font-size: 40px;
   line-height: 130%;
 }
@@ -123,7 +123,7 @@ body {
   background: #b30c37;
   color: white;
   text-align: left;
-  font-family: "Roboto", sans-serif;
+  font-family: 'Roboto', sans-serif;
   font-size: 32px;
   font-weight: normal;
   letter-spacing: 0.02em;
@@ -185,7 +185,7 @@ body {
 .reveal pre > code, .reveal .code {
   color: black;
   max-height: none;
-  font-family: "Inconsolata", monospace;
+  font-family: 'Inconsolata', monospace;
   font-size: 24px;
   line-height: normal;
 }
@@ -195,7 +195,7 @@ body {
  *********************************************/
 
 .reveal section.page-title {
-  background: transparent center center no-repeat url('images/title-background.png');
+  background: transparent center center no-repeat url('./images/title-background.png');
   background-size: 100%;
 }
 


### PR DESCRIPTION
- feat: ouverture forcée dans Chrome 	
- feat: ajout d'un mode debug pour les PDF
- feat: screenshot & HTML sauvegardé en mode debug des PDF avec PhantomJS
- feat: ajout de logs avec timestamp
- feat: montée de la version en 0.4.5 + change log
- fix: génération de PDF dans le navigateur
- fix: génération de PDF avec PhantomJS
	- fix: problème avec PhantomJS 1.x qui ne gère pas les `Promise`
	- fix: ajout d'un polyfill qui ne s'active que si les `Promise` n'existe pas dans le browser
	- fix: problème avec PhantomJS et XMLHttpRequest
	- fix: augmentation du temps d'attente avant la création du PDF (1000ms -> 10000ms)

Tests effectués avec NPM2 :
- ouverture de la formation avec `grunt`
- génération de PDF utilisant PhantomJS avec `grunt generateSlidesPDF`

Tests effectués avec NPM3 :
- ouverture de la formation avec `gulp`
- génération de PDF dans le navigateur (pas encore fait de goal pour Gulp pour la génération de PDF)

Aucune modification pour la génération des PDF du cahier de TP et les autres taches.

Fixes #87