### PR TITLE
feat: gruntfile compatible avec npm 2 et 3

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,6 @@
 
     <title>FORMATION_NAME</title>
     <link rel="icon" type="image/png" href="favicon.png">
-    <!-- pour NPM 2 -->
-    <link rel="stylesheet" href="node_modules/reveal.js/css/reveal.min.css">
-    <!-- pour NPM 3-->
     <link rel="stylesheet" href="reveal.js/css/reveal.min.css">
 
     <link rel="stylesheet" href="reveal/theme-zenika/theme.css" id="theme">
@@ -34,10 +31,6 @@
         </footer>
     </div>
 
-    <!-- pour NPM 2 -->
-    <script src="node_modules/reveal.js/lib/js/head.min.js"></script>
-    <script src="node_modules/reveal.js/js/reveal.min.js"></script>
-    <!-- pour NPM 3-->
     <script src="reveal.js/lib/js/head.min.js"></script>
     <script src="reveal.js/js/reveal.min.js"></script>
 


### PR DESCRIPTION
Cf #77. C'est pas particulièrement beau ou performant, mais je pense que c'est mieux que 2 builds différents.

J'ai aussi modifié les chemins qu'expose le serveur pour que `index.html` n'est pas à supporter des chemins différents pour npm 2 et 3.