### PR TITLE
Support some presentation remotes

### DIFF
--- a/reveal/run.js
+++ b/reveal/run.js
@@ -40,6 +40,7 @@
         38: function upArrow() { if (isRemoteMode()) Reveal.prev(); else Reveal.up(); },
         39: function rightArrow() { if (isRemoteMode()) Reveal.next(); else Reveal.right(); },
         40: function downArrow() { if (isRemoteMode()) Reveal.next(); else Reveal.down(); },
+        82: function rKey() { toggleRemoteMode(); },
       },
       margin: 0,
       maxScale: 2.0,
@@ -73,10 +74,36 @@
     });
   }
 
+  function hasRemoteQueryParameter() {
+    return window.location.search.match(/[?&]remote[&]?/i);
+  }
+
   function isRemoteMode() {
     return Reveal.isOverview()
                   ? false
-                  : window.location.search.match(/[?&]remote[&]?/i);
+                  : hasRemoteQueryParameter();
+  }
+
+  function enableRemoteMode() {
+    if (window.location.search.match(/[?]/))
+      window.location.search = window.location.search + '&remote';
+    else
+      window.location.search = '?remote';
+  }
+
+  function disableRemoteMode() {
+    window.location.search = window.location.search
+	.replace(/[?]remote[&]/i, '?')
+        .replace(/[?]remote/i, '')
+	.replace(/[&]remote[&]/i, '&')
+        .replace(/[&]remote$/i, '');
+  }
+
+  function toggleRemoteMode() {
+    if (hasRemoteQueryParameter())
+      disableRemoteMode();
+    else
+      enableRemoteMode();
   }
 
   function appendStylesheetWhenUrlMatches(head, regexp, stylesheets) {

--- a/reveal/run.js
+++ b/reveal/run.js
@@ -37,24 +37,24 @@
       mouseWheel: true,
       keyboard: {
         37: function leftArrow() {
-              if (isRemoteMode()) Reveal.prev();
-              else Reveal.left();
-            },
+          if (isRemoteMode()) Reveal.prev();
+          else Reveal.left();
+        },
         38: function upArrow() {
-              if (isRemoteMode()) Reveal.prev();
-              else Reveal.up();
-            },
+          if (isRemoteMode()) Reveal.prev();
+          else Reveal.up();
+        },
         39: function rightArrow() {
-              if (isRemoteMode()) Reveal.next();
-              else Reveal.right();
-            },
+          if (isRemoteMode()) Reveal.next();
+          else Reveal.right();
+        },
         40: function downArrow() {
-              if (isRemoteMode()) Reveal.next();
-              else Reveal.down();
-            },
+          if (isRemoteMode()) Reveal.next();
+          else Reveal.down();
+        },
         82: function rKey() {
-              toggleRemoteMode();
-            },
+          toggleRemoteMode();
+        },
       },
       margin: 0,
       maxScale: 2.0,
@@ -94,22 +94,22 @@
 
   function isRemoteMode() {
     return Reveal.isOverview()
-                  ? false
-                  : hasRemoteQueryParameter();
+      ? false
+      : hasRemoteQueryParameter();
   }
 
   function enableRemoteMode() {
     window.location.search += window.location.search.match(/[?]/)
-                           ? '&remote'
-                           : "?remote";
+      ? '&remote'
+      : '?remote';
   }
 
   function disableRemoteMode() {
     window.location.search = window.location.search
-        .replace(/[?]remote[&]/i, '?')
-        .replace(/[?]remote/i, '')
-        .replace(/[&]remote[&]/i, '&')
-        .replace(/[&]remote$/i, '');
+      .replace(/[?]remote[&]/i, '?')
+      .replace(/[?]remote/i, '')
+      .replace(/[&]remote[&]/i, '&')
+      .replace(/[&]remote$/i, '');
   }
 
   function toggleRemoteMode() {

--- a/reveal/run.js
+++ b/reveal/run.js
@@ -36,10 +36,10 @@
       slideNumber: false,
       mouseWheel: true,
       keyboard: {
-        37: function leftArrow() { if (Reveal.isOverview()) Reveal.left(); else Reveal.prev(); },
-        38: function upArrow() { if (Reveal.isOverview()) Reveal.up(); else Reveal.prev(); },
-        39: function rightArrow() { if (Reveal.isOverview()) Reveal.right(); else Reveal.next(); },
-        40: function downArrow() { if (Reveal.isOverview()) Reveal.down(); else Reveal.next(); },
+        37: function leftArrow() { if (isRemoteMode()) Reveal.prev(); else Reveal.left(); },
+        38: function upArrow() { if (isRemoteMode()) Reveal.prev(); else Reveal.up(); },
+        39: function rightArrow() { if (isRemoteMode()) Reveal.next(); else Reveal.right(); },
+        40: function downArrow() { if (isRemoteMode()) Reveal.next(); else Reveal.down(); },
       },
       margin: 0,
       maxScale: 2.0,
@@ -73,6 +73,11 @@
     });
   }
 
+  function isRemoteMode() {
+    return Reveal.isOverview()
+                  ? false
+                  : window.location.search.match(/[?&]remote[&]?/i);
+  }
 
   function appendStylesheetWhenUrlMatches(head, regexp, stylesheets) {
     if (window.location.search.match(regexp)) {

--- a/reveal/run.js
+++ b/reveal/run.js
@@ -36,11 +36,25 @@
       slideNumber: false,
       mouseWheel: true,
       keyboard: {
-        37: function leftArrow() { if (isRemoteMode()) Reveal.prev(); else Reveal.left(); },
-        38: function upArrow() { if (isRemoteMode()) Reveal.prev(); else Reveal.up(); },
-        39: function rightArrow() { if (isRemoteMode()) Reveal.next(); else Reveal.right(); },
-        40: function downArrow() { if (isRemoteMode()) Reveal.next(); else Reveal.down(); },
-        82: function rKey() { toggleRemoteMode(); },
+        37: function leftArrow() {
+              if (isRemoteMode()) Reveal.prev();
+              else Reveal.left();
+            },
+        38: function upArrow() {
+              if (isRemoteMode()) Reveal.prev();
+              else Reveal.up();
+            },
+        39: function rightArrow() {
+              if (isRemoteMode()) Reveal.next();
+              else Reveal.right();
+            },
+        40: function downArrow() {
+              if (isRemoteMode()) Reveal.next();
+              else Reveal.down();
+            },
+        82: function rKey() {
+              toggleRemoteMode();
+            },
       },
       margin: 0,
       maxScale: 2.0,
@@ -85,25 +99,22 @@
   }
 
   function enableRemoteMode() {
-    if (window.location.search.match(/[?]/))
-      window.location.search = window.location.search + '&remote';
-    else
-      window.location.search = '?remote';
+    window.location.search += window.location.search.match(/[?]/)
+                           ? '&remote'
+                           : "?remote";
   }
 
   function disableRemoteMode() {
     window.location.search = window.location.search
-	.replace(/[?]remote[&]/i, '?')
+        .replace(/[?]remote[&]/i, '?')
         .replace(/[?]remote/i, '')
-	.replace(/[&]remote[&]/i, '&')
+        .replace(/[&]remote[&]/i, '&')
         .replace(/[&]remote$/i, '');
   }
 
   function toggleRemoteMode() {
-    if (hasRemoteQueryParameter())
-      disableRemoteMode();
-    else
-      enableRemoteMode();
+    if (hasRemoteQueryParameter()) disableRemoteMode();
+    else enableRemoteMode();
   }
 
   function appendStylesheetWhenUrlMatches(head, regexp, stylesheets) {

--- a/reveal/run.js
+++ b/reveal/run.js
@@ -35,6 +35,12 @@
       rollingLinks: true,
       slideNumber: false,
       mouseWheel: true,
+      keyboard: {
+        37: function leftArrow() { if (Reveal.isOverview()) Reveal.left(); else Reveal.prev(); },
+        38: function upArrow() { if (Reveal.isOverview()) Reveal.up(); else Reveal.prev(); },
+        39: function rightArrow() { if (Reveal.isOverview()) Reveal.right(); else Reveal.next(); },
+        40: function downArrow() { if (Reveal.isOverview()) Reveal.down(); else Reveal.next(); },
+      },
       margin: 0,
       maxScale: 2.0,
       width: 1124,


### PR DESCRIPTION
Some presentation remotes use Left/Right to navigate the slides.
By default Reveal uses those for column/chapter navigation.
This is far less useful than slide navigation.

This patch lets the presenter use Left/Right to navigate slides, but
still Does The Right Thing in overview mode.

We also map the Up/Down arrows for consistency.